### PR TITLE
Fix physicslist construction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+build
+install
+.local
+.vscode
+
+# G4 outputs
+*.root
+*.hdf5
+
+# G4 visualization
+bookmarkFile
+*.pdf
+*.iv
+
+compile_commands.json
+
+# junk
+*.DS_Store
+*.swp
+*.swo
+.mypy_cache
+__pycache__
+*.dat
+
+# python
+.venv

--- a/particle.cc
+++ b/particle.cc
@@ -2,15 +2,19 @@
 #include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 
+MyCustomParticle* MyCustomParticle::theWIMP = nullptr;
 // Singleton-Instanz
 MyCustomParticle* MyCustomParticle::Instance() {
-    static MyCustomParticle instance;
-    return &instance;
+    return theWIMP;
 }
 
 // Definition des Partikels
 MyCustomParticle* MyCustomParticle::Definition() {
-    return Instance();
+    if(!theWIMP) {
+        theWIMP = new MyCustomParticle();
+        G4cout << "New WIMP created" << G4endl;
+    }
+    return theWIMP;
 }
 
 // Konstruktor

--- a/particle.hh
+++ b/particle.hh
@@ -12,6 +12,7 @@ public:
 private:
     MyCustomParticle();
     ~MyCustomParticle();
+    static MyCustomParticle* theWIMP;
 };
 
 #endif

--- a/physics.cc
+++ b/physics.cc
@@ -4,34 +4,44 @@
 
 MyPhysicsList::MyPhysicsList()
 {
-	RegisterPhysics (new G4EmStandardPhysics());
-	RegisterPhysics (new G4OpticalPhysics());
-	RegisterPhysics (new G4DecayPhysics());
-	RegisterPhysics (new G4RadioactiveDecayPhysics());	
+	//RegisterPhysics (new G4EmStandardPhysics());
+	//RegisterPhysics (new G4OpticalPhysics());
+	//RegisterPhysics (new G4DecayPhysics());
+	//RegisterPhysics (new G4RadioactiveDecayPhysics());	
 
-	MyCustomParticle::Definition();
-
-	G4ParticleDefinition* particle = MyCustomParticle::Definition();
-	G4ProcessManager* pmanager = particle->GetProcessManager();
-
-	auto weakInteraction = new WimpWeakInteraction();
-	pmanager->AddDiscreteProcess(weakInteraction);
-			//pmanager->SetProcessOrderingToFirst(weakInteraction, idxPostStep);
-	   	//}
-	   	if (pmanager) {
-    			G4cout << "Registering WimpWeakInteraction for particle: " 
-           		<< particle->GetParticleName() << G4endl;
 }
-		auto processList = pmanager->GetProcessList();
-		if (processList) {
-		    G4cout << "Processes registered for particle: " 
-			   << particle->GetParticleName() << G4endl;
-		    for (size_t i = 0; i < processList->size(); ++i) {
-			G4cout << " - " << (*processList)[i]->GetProcessName() << G4endl;
-		    }
-		}
-
-	}
 
 MyPhysicsList::~MyPhysicsList()
 {}
+
+void MyPhysicsList::ConstructParticle()
+{
+  MyCustomParticle::Definition();
+}
+
+void MyPhysicsList::ConstructProcess()
+{
+  AddTransportation();
+
+  G4ParticleDefinition* particle = MyCustomParticle::Definition();
+  G4ProcessManager* pmanager = particle->GetProcessManager();
+  if(!pmanager)
+  	G4cout << "No pmanager" << G4endl;
+  auto weakInteraction = new WimpWeakInteraction();
+  pmanager->AddDiscreteProcess(weakInteraction);
+  		//pmanager->SetProcessOrderingToFirst(weakInteraction, idxPostStep);
+     	//}
+  if (pmanager) {
+  		G4cout << "Registering WimpWeakInteraction for particle: " 
+     		<< particle->GetParticleName() << G4endl;
+  }
+  auto processList = pmanager->GetProcessList();
+  if (processList) {
+      G4cout << "Processes registered for particle: " 
+  	   << particle->GetParticleName() << G4endl;
+      for (size_t i = 0; i < processList->size(); ++i) {
+  	G4cout << " - " << (*processList)[i]->GetProcessName() << G4endl;
+      }
+  }
+
+}

--- a/physics.hh
+++ b/physics.hh
@@ -12,6 +12,9 @@ class MyPhysicsList : public G4VModularPhysicsList
 public:
 	MyPhysicsList();
 	~MyPhysicsList();
+
+	virtual void ConstructParticle();
+	virtual void ConstructProcess();
 };
 
 #endif


### PR DESCRIPTION
Ich hab den Singleton in `particle` korrigiert, wobei das anscheinend nicht das problem war. Die physics hat seperate funktionen um das Teilchen zu erzeugen und die jeweiligen Prozesse hinzuzufügen. Das war bei dir alles in einer Funktion, was dazu geführt hat das die neuen WIMPS am ende nur die Standard constructor prozesse hatten (transportation und Scintillation). 

Jetzt funktioniert zumindest der WIMP Prozess, wenn du weitere Prozesse hinzufügen möchtest, musst du das manuel in der `ConstructProcess()` funktion machen. Das funktioniert wahrscheinlich nicht mehr über die RegisterPhysics constructoren.